### PR TITLE
Fixed bug where variable length data wouldn't load correctly

### DIFF
--- a/METdbLoad/ush/constants.py
+++ b/METdbLoad/ush/constants.py
@@ -727,6 +727,7 @@ for line_type in UC_LINE_TYPES_TCST:
 
     if line_type in VAR_LINE_TYPES_TCST:
         LINE_DATA_COLS_TCST[line_type] = [LINE_DATA_ID] + LINE_DATA_COLS_TCST[line_type]
+        LINE_DATA_FIELDS[line_type] = [LINE_DATA_ID] + LINE_DATA_FIELDS[line_type]
 
     # For each line type, create insert queries
     VALUE_SLOTS = '%s, ' * len(LINE_DATA_FIELDS[line_type])
@@ -773,6 +774,7 @@ for line_type in UC_LINE_TYPES:
 
     if line_type in VAR_LINE_TYPES:
         LINE_DATA_COLS[line_type] = [LINE_DATA_ID] + LINE_DATA_COLS[line_type]
+        LINE_DATA_FIELDS[line_type] = [LINE_DATA_ID] + LINE_DATA_FIELDS[line_type]
 
     # For each line type, create insert queries
     VALUE_SLOTS = '%s, ' * len(LINE_DATA_FIELDS[line_type])

--- a/METdbLoad/ush/run_sql.py
+++ b/METdbLoad/ush/run_sql.py
@@ -184,7 +184,7 @@ class RunSql:
                             str)
                         raw_data['fcst_init'] = raw_data['fcst_init'].astype(
                             str)
-                    else:
+                    elif 'fcst_valid_beg' in raw_data:
                         raw_data['fcst_valid_beg'] = raw_data[
                             'fcst_valid_beg'].astype(str)
                         raw_data['fcst_valid_end'] = raw_data[


### PR DESCRIPTION
I discovered a bug in METdbload where variable-length data rows were throwing errors rather than loading into the database. This turned out to be because the stat headers were adjusted for the variable length, but not the data fields. Both are now adjusted properly. I also fixed a related if statement bug that was producing a KeyError.